### PR TITLE
Flatpak: Remove accountsservice hole

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -12,7 +12,6 @@
         "--socket=wayland",
         "--filesystem=home",
         "--metadata=X-DConf=migrate-path=/org/gnome/file-roller/",
-        "--system-talk-name=org.freedesktop.Accounts",
         "--own-name=org.gnome.ArchiveManager1"
     ],
     "cleanup": [


### PR DESCRIPTION
No longer needed because of new settings portal