### PR TITLE
Add support for SquashFS files

### DIFF
--- a/fr-squashfs-tools-4.5.patch
+++ b/fr-squashfs-tools-4.5.patch
@@ -1,0 +1,16 @@
+--- a/src/fr-command-unsquashfs.c	2021-09-20 21:59:59.000000000 +0300
++++ b/src/fr-command-unsquashfs.c	2021-09-25 12:04:18.507582175 +0300
+@@ -58,13 +58,6 @@
+ 
+         g_return_if_fail (line != NULL);
+ 
+-        /* Skip header */
+-        if (!d->read_header) {
+-                if (line[0] == '\0')
+-                        d->read_header = TRUE;
+-                return;
+-        }
+-
+         fdata = file_data_new ();
+ 
+         fields = _g_str_split_line (line, 5);

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -107,6 +107,40 @@
             ]
         },
         {
+            "name": "lzo",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz",
+                    "sha1": "4924676a9bae5db58ef129dc1cebce3baa3c4b5d"
+                }
+            ]
+        },
+        {
+            "name": "squashfs-tools",
+            "buildsystem": "autotools",
+            "no-autogen": true,
+            "subdir": "squashfs-tools",
+            "make-args": [
+                "LZ4_SUPPORT=1",
+                "LZO_SUPPORT=1",
+                "XZ_SUPPORT=1",
+                "ZSTD_SUPPORT=1"
+            ],
+            "make-install-args": [
+                "INSTALL_DIR=/app/bin"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/plougher/squashfs-tools.git",
+                    "tag": "4.5",
+                    "commit": "0496d7c3de3e09da37ba492081c86159806ebb07"
+                }
+            ]
+        },
+        {
             "name": "file-roller",
             "buildsystem": "meson",
             "cleanup": [
@@ -134,6 +168,10 @@
                 {
                     "type": "patch",
                     "path": "fr-remove-open-with.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "fr-squashfs-tools-4.5.patch"
                 }
             ]
         },


### PR DESCRIPTION
[SquashFS](https://github.com/plougher/squashfs-tools), while traditionally used for LiveCD filesystems, is also very useful as an archiving format and replacement for `tar` (which has many frustrating limitations, especially regarding large archives.) More importantly, it has a funny name, which amuses me in particular.

This PR installs the `squashfs-tools` utilities into the Flatpak, enabling File Roller to read SquashFS files.

The LZO library is also added, as SquashFS supports LZO compression. This has the added benefit of also enabling support for LZO-compressed tar archives.

Unfortunately, there seems to be no way to avoid adding a patch to enable this, as `squashfs-tools` 4.5 [made a change to the output of `unsquashfs`](https://gitlab.gnome.org/GNOME/file-roller/-/issues/136) that causes File Roller to fail to read SquashFS files. This issue was filed 2 months ago but there hasn't be a response yet.

Downgrading to `squashfs-tools` 4.4 would also require a patch as the older code base doesn't seem to play nicely with GCC 10+. The main issue seems to be related to [this change in GCC 10.0](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678), however adding [`-fcommon`](https://wiki.gentoo.org/wiki/Project:Toolchain/Gcc_10_porting_notes/fno_common) to `CFLAGS` wasn't enough to get 4.4 to compile, it just resulted in different errors.

It's possible this could still be fixed with build options alone, but I don't know enough about C or `gcc` to say one way or the other.

In light of all this, I chose to compile that latest 4.5 version of `squashfs-tools` and add a small patch for File Roller sourced from the above GitLab issue. The patch essentially just yeets the code that is normally used to ignore the header, which no longer exists. Computers are fun.

This is probably only my third PR ever, so constructive feedback is appreciated.