### PR TITLE
Make sure to use our own icon

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('org.gnome.ArchiveManager',
+project('org.gnome.FileRoller',
     meson_version: '>= 0.57.0'
 )
 

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -4,8 +4,6 @@
     "runtime-version": "7.1",
     "sdk": "io.elementary.Sdk",
     "command": "file-roller",
-    "rename-icon": "org.gnome.ArchiveManager",
-    "copy-icon": true,
     "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",
@@ -131,7 +129,7 @@
             "buildsystem": "meson",
             "cleanup": [
                 "org.gnome.FileRoller.ArchiveManager1.service",
-                "org.gnome.ArchiveManager.svg"
+                "org.gnome.FileRoller.svg"
             ],
             "builddir": true,
             "sources": [


### PR DESCRIPTION
Upstream renamed the icon name in the following commit, and our icon are not used since then:
https://gitlab.gnome.org/GNOME/file-roller/-/commit/ed220eb35bd8459898fd78aed6d7867c86ddd220

### Before
![スクリーンショット 2023-04-01 12 48 26](https://user-images.githubusercontent.com/26003928/229264769-24571c13-63b9-408c-b82f-f0a0708d0ccc.png)

### After
![スクリーンショット 2023-04-01 12 57 11](https://user-images.githubusercontent.com/26003928/229264774-cb279777-4a8e-44bb-b460-70a939d986d8.png)
