### PR TITLE
Follow file rename in upstream

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -130,7 +130,7 @@
             "name": "file-roller",
             "buildsystem": "meson",
             "cleanup": [
-                "org.gnome.FileRoller.ArchiveManager1.service",
+                "org.gnome.ArchiveManager1.service",
                 "org.gnome.ArchiveManager.svg"
             ],
             "builddir": true,


### PR DESCRIPTION
Upstream renamed the service file name in the following commit:
https://gitlab.gnome.org/GNOME/file-roller/-/commit/5d48ddc3002fa8257a56eaedee44cdf694e1d861