### PR TITLE
Add flatpak-external-data-checker workflow

### DIFF
--- a/.github/workflows/flatpak-x-checker.yml
+++ b/.github/workflows/flatpak-x-checker.yml
@@ -1,0 +1,23 @@
+name: Check for updates
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 0 * * 1" # run weekly
+  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork org.gnome.FileRoller.json

--- a/fix-metainfo.patch
+++ b/fix-metainfo.patch
@@ -1,0 +1,13 @@
+diff --git a/data/org.gnome.FileRoller.appdata.xml.in b/data/org.gnome.FileRoller.appdata.xml.in
+index 6d24b0a0ba17c95476d205ef04f48610fbbfa678..7c44194e68ade2c9e22220c72f5decf143c6c323 100644
+--- a/data/org.gnome.FileRoller.appdata.xml.in
++++ b/data/org.gnome.FileRoller.appdata.xml.in
+@@ -49,7 +49,7 @@
+ 
+   <releases>
+     <release version="43.0" date="2022-09-17"/>
+-    <release version="43.alpha" date="2022-08-17" type="development"/>
++    <release version="43~alpha" date="2022-08-17" type="development"/>
+     <release version="3.42.0" date="2022-03-20"/>
+     <release version="3.41.90" date="2022-02-23" type="development"/>
+     <release version="3.40.0" date="2021-05-01"/>

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -29,7 +29,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/p7zip-project/p7zip/archive/refs/tags/v17.04.tar.gz",
-                    "sha256": "ea029a2e21d2d6ad0a156f6679bd66836204aa78148a4c5e498fe682e77127ef"
+                    "sha256": "ea029a2e21d2d6ad0a156f6679bd66836204aa78148a4c5e498fe682e77127ef",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/p7zip-project/p7zip/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": "\"https://github.com/p7zip-project/p7zip/archive/refs/tags/\\($version).tar.gz\""
+                    }
                 }
             ]
         },
@@ -44,7 +50,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/gnustep/tools-make/releases/download/make-2_9_0/gnustep-make-2.9.0.tar.gz",
-                    "sha256": "a0b066c11257879c7c85311dea69c67f6dc741ef339db6514f85b64992c40d2a"
+                    "sha256": "a0b066c11257879c7c85311dea69c67f6dc741ef339db6514f85b64992c40d2a",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/gnustep/tools-make/releases/latest",
+                        "version-query": ".tag_name | sub(\"^make-\"; \"\") | gsub(\"_\"; \".\")",
+                        "url-query": ".assets[] | select(.name==\"gnustep-make-\" + $version + \".tar.gz\") | .browser_download_url"
+                    }
                 }
             ]
         },
@@ -60,7 +72,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/gnustep/libs-base/releases/download/base-1_28_0/gnustep-base-1.28.0.tar.gz",
-                    "sha256": "c7d7c6e64ac5f5d0a4d5c4369170fc24ed503209e91935eb0e2979d1601039ed"
+                    "sha256": "c7d7c6e64ac5f5d0a4d5c4369170fc24ed503209e91935eb0e2979d1601039ed",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/gnustep/libs-base/releases/latest",
+                        "version-query": ".tag_name | sub(\"^base-\"; \"\") | gsub(\"_\"; \".\")",
+                        "url-query": ".assets[] | select(.name==\"gnustep-base-\" + $version + \".tar.gz\") | .browser_download_url"
+                    }
                 }
             ]
         },
@@ -88,7 +106,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/facebook/zstd/releases/download/v1.4.8/zstd-1.4.8.tar.gz",
-                    "sha256": "32478297ca1500211008d596276f5367c54198495cf677e9439f4791a4c69f24"
+                    "sha256": "32478297ca1500211008d596276f5367c54198495cf677e9439f4791a4c69f24",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/facebook/zstd/releases/latest",
+                        "version-query": ".tag_name | sub(\"^v|\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"zstd-\" + $version + \".tar.gz\") | .browser_download_url"
+                    }
                 }
             ]
         },
@@ -120,9 +144,15 @@
             ],
             "sources" : [
                 {
-                    "type": "git",
-                    "url": "https://github.com/flatpak/libportal.git",
-                    "tag": "0.6"
+                    "type": "archive",
+                    "url": "https://github.com/flatpak/libportal/releases/download/0.6/libportal-0.6.tar.xz",
+                    "sha256": "88a12c3ba71bc31acff7238c280de697d609cebc50830c3766776ec35abc6566",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/flatpak/libportal/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".assets[] | select(.name==\"libportal-\" + $version + \".tar.xz\") | .browser_download_url"
+                    }
                 }
             ]
         },
@@ -136,9 +166,17 @@
             "builddir": true,
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/file-roller.git",
-                    "commit": "1a3cd7a8e0465011ac3c74252fae0ccc14d3aa15"
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/file-roller/43/file-roller-43.0.tar.xz",
+                    "sha256": "298729fdbdb9da8132c0bbc60907517d65685b05618ae05167335e6484f573a1",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "file-roller"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "fix-metainfo.patch"
                 }
             ]
         },


### PR DESCRIPTION
This should automatically open PRs when new versions of things in the flatpak manifest become available.

I've submitted the changes to the manifest upstream at: https://gitlab.gnome.org/GNOME/file-roller/-/merge_requests/97