### PR TITLE
p7zip: Set a writable destination for install

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -21,8 +21,10 @@
             "name": "p7zip",
             "no-autogen": true,
             "make-args": [
-                "DEST_HOME=/app",
                 "7z"
+            ],
+            "make-install-args": [
+                "DEST_HOME=/app"
             ],
             "sources": [
                 {

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -21,6 +21,7 @@
             "name": "p7zip",
             "no-autogen": true,
             "make-args": [
+                "DEST_HOME=/app",
                 "7z"
             ],
             "sources": [


### PR DESCRIPTION
This is broken upstream, `p7zip` isn't actually being installed because the prefix doesn't get set.

Upstream PR submitted here:
https://gitlab.gnome.org/GNOME/file-roller/-/merge_requests/98