### PR TITLE
Update org.gnome.FileRoller.json

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -8,6 +8,7 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
+        "--device=dri",
         "--filesystem=home",
         "--filesystem=/tmp",
         "--metadata=X-DConf=migrate-path=/org/gnome/file-roller/",


### PR DESCRIPTION
Fixes elementary/triage#676.
